### PR TITLE
Try Baskervville font from GoogleFonts

### DIFF
--- a/src/quickstart/config.toml
+++ b/src/quickstart/config.toml
@@ -5,5 +5,3 @@ theme = "ananke"
 commentoEnable = true
 disqusShortname = 'osr-role-playing'
 
-[params]
-  post_content_classes = "Baskerville bg-near-white"

--- a/src/quickstart/config.toml
+++ b/src/quickstart/config.toml
@@ -6,4 +6,4 @@ commentoEnable = true
 disqusShortname = 'osr-role-playing'
 
 [params]
-  post_content_classes = "'ITC Souvenir Light' bg-near-white"
+  post_content_classes = "'Baskerville, Garamond, Palatino, Times New Roman, Times' bg-near-white"

--- a/src/quickstart/config.toml
+++ b/src/quickstart/config.toml
@@ -6,4 +6,4 @@ commentoEnable = true
 disqusShortname = 'osr-role-playing'
 
 [params]
-  post_content_classes = "Baskerville, Garamond, Palatino, Times New Roman, Times bg-near-white"
+  post_content_classes = "Baskerville bg-near-white"

--- a/src/quickstart/config.toml
+++ b/src/quickstart/config.toml
@@ -7,3 +7,4 @@ disqusShortname = 'osr-role-playing'
 
 [params]
   body_classes = "baskervvile bg-near-white"
+  post_content_classes = "baskervvile bg-near-white"

--- a/src/quickstart/config.toml
+++ b/src/quickstart/config.toml
@@ -6,4 +6,4 @@ commentoEnable = true
 disqusShortname = 'osr-role-playing'
 
 [params]
-  post_content_classes = "'Baskerville, Garamond, Palatino, Times New Roman, Times' bg-near-white"
+  post_content_classes = "Baskerville, Garamond, Palatino, Times New Roman, Times bg-near-white"

--- a/src/quickstart/config.toml
+++ b/src/quickstart/config.toml
@@ -5,3 +5,5 @@ theme = "ananke"
 commentoEnable = true
 disqusShortname = 'osr-role-playing'
 
+[params]
+  body_classes = "baskervvile bg-near-white"

--- a/src/quickstart/layouts/partials/head-additions.html
+++ b/src/quickstart/layouts/partials/head-additions.html
@@ -1,0 +1,4 @@
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&family=Source+Code+Pro:ital,wght@1,300&display=swap" rel="stylesheet">

--- a/src/quickstart/layouts/partials/head-additions.html
+++ b/src/quickstart/layouts/partials/head-additions.html
@@ -2,3 +2,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Baskervville&family=Source+Code+Pro:ital,wght@1,300&display=swap" rel="stylesheet">
+    <style>
+      body {
+        font-family: 'Baskervvile';
+        font-size: 20px;
+      }
+    </style>`

--- a/src/quickstart/layouts/partials/head-additions.html
+++ b/src/quickstart/layouts/partials/head-additions.html
@@ -2,9 +2,3 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Baskervville&family=Source+Code+Pro:ital,wght@1,300&display=swap" rel="stylesheet">
-    <style>
-      body {
-        font-family: 'Baskervvile';
-        font-size: 20px;
-      }
-    </style>`


### PR DESCRIPTION
closes #13 

The [Google Fonts API page](https://developers.google.com/fonts/docs/css2#quickstart_guides) gives the info needed for including their open-source fonts. Adding these three lines to src/layouts/partials/head-additions.html (new file):
```html
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
<link href="https://fonts.googleapis.com/css2?family=Baskervville&family=Source+Code+Pro:ital,wght@1,300&display=swap" rel="stylesheet">
```

and then specifying the Baskervvile font in config.toml:
```toml
[params]
  body_classes = "baskervvile bg-near-white"
  post_content_classes = "baskervvile bg-near-white"
```